### PR TITLE
Update to HTTPS URLs

### DIFF
--- a/conf/genregionmap/ecuador-from-planet.dotenv
+++ b/conf/genregionmap/ecuador-from-planet.dotenv
@@ -1,3 +1,3 @@
-FULL_MAP_URL="http://planet.openstreetmap.org/pbf/planet-latest.osm.pbf"
-REGION_POLYGON_URL="http://download.geofabrik.de/south-america/ecuador.poly"
-OSMOSIS_URL="http://bretth.dev.openstreetmap.org/osmosis-build/osmosis-latest.tgz"
+FULL_MAP_URL="https://planet.openstreetmap.org/pbf/planet-latest.osm.pbf"
+REGION_POLYGON_URL="https://download.geofabrik.de/south-america/ecuador.poly"
+OSMOSIS_URL="https://bretth.dev.openstreetmap.org/osmosis-build/osmosis-latest.tgz"


### PR DESCRIPTION
planet.openstreetmap.org will redirect to HTTPS at some point in the future.
In addition to that change, I moved the other URLs in this configuration to HTTPS.
This is particularly important for Osmosis, where a binary is downloaded.

See also openstreetmap/operations#200